### PR TITLE
issue 32 - Added a super basic "remember me" function.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,9 @@ var Encryptr = (function (window, console, undefined) {
     window.document.addEventListener("offline", this.setOffline, false);
     window.document.addEventListener("online", this.setOnline, false);
 
+    var settings = window.localStorage.getItem("settings") || "{}";
+    window.app.settings = JSON.parse(settings);
+
     // Set the hostname for the Crypton server
     // window.crypton.host = "192.168.1.12";
     window.crypton.host = "localhost";

--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -30,6 +30,10 @@
       window.setTimeout(function() {
         _this.signupView.$el.removeClass("hidden");
       }, 100);
+      if (window.app.settings && window.app.settings.username) {
+        $("#username").val(window.app.settings.username);
+        $("#passphrase").focus();
+      }
       return this;
     },
     input_focusHandler: function(event) {
@@ -58,6 +62,8 @@
           $(".blocker").hide();
           return;
         }
+        window.app.settings = _.extend(window.app.settings, {username: username});
+        window.localStorage.setItem("settings", JSON.stringify(window.app.settings));
         window.app.session = session;
         window.app.accountModel = new window.app.AccountModel({
           username: username,
@@ -98,7 +104,16 @@
       var _this = this;
       if (_this.$el.hasClass("dismissed")) {
         _this.$el.removeClass("dismissed");
-        _this.$el.animate({"-webkit-transform":"translate3d(0,0,0)"}, 250, "ease-in-out");
+        _this.$el.animate({"-webkit-transform":"translate3d(0,0,0)"}, {
+          duration: 250,
+          easing: "ease-in-out",
+          complete: function() {
+            if (window.app.settings && window.app.settings.username) {
+              $("#username").val(window.app.settings.username);
+              $("#passphrase").focus();
+            }
+          }
+        });
       }
     },
     disable: function() {

--- a/src/views/MenuView.js
+++ b/src/views/MenuView.js
@@ -26,6 +26,10 @@
       event.preventDefault();
       window.app.loginView.disable();
       this.dismiss();
+      if (window.app.settings && window.app.settings.username) {
+        delete window.app.settings.username;
+        window.localStorage.setItem("settings", JSON.stringify(window.app.settings));
+      }
       // Throw up the login screen
       window.app.loginView.show();
       window.setTimeout(function() {

--- a/src/views/SignupView.js
+++ b/src/views/SignupView.js
@@ -64,6 +64,8 @@
             $(".blocker").hide();
             return;
           }
+          window.app.settings = _.extend(window.app.settings, {username: username});
+          window.localStorage.setItem("settings", JSON.stringify(window.app.settings));
           window.app.session = session;
           window.app.accountModel = new window.app.AccountModel({
             username: username,

--- a/www/config.xml
+++ b/www/config.xml
@@ -18,4 +18,5 @@
     <preference name="DisallowOverscroll" value="true" />
     <preference name="AutoHideSplashScreen" value="true" />
     <preference name="BackupWebStorage" value="none" />
+    <preference name="KeyboardDisplayRequiresUserAction" value="false"/>
 </widget>


### PR DESCRIPTION
Successful login remembers the username until the user chooses "log out" from the menu.

At least on iOS, the passphrase field focuses on start up and resume to make getting into the app a bit quicker when the username is remembered.
- System now has an `app.settings` stored in localStorage.
- Only current setting is `username`

Fixes #32 
