### PR TITLE
Implemented a local encrypted cache

### DIFF
--- a/src/views/EntriesView.js
+++ b/src/views/EntriesView.js
@@ -66,7 +66,7 @@
           window.sjcl.decrypt(window.app.accountModel.get("passphrase"),
                               encryptedIndexJSON, window.crypton.cipherOptions);
         this.collection.set(JSON.parse(decryptedIndexJson));
-        this.$(".entriesViewLoading").text("Syncing entries...");
+        this.$(".entriesViewLoading").text("syncing entries...");
         this.$(".entriesViewLoading").addClass("loadingEntries");
       }
       this.collection.fetch({


### PR DESCRIPTION
Note: this is a temporary enhancement until Crypton gets container compaction (https://github.com/SpiderOak/crypton/issues/307) and offline access.

Replaced the plain text temporary sessionStorage with an encrypted persistent localStorage. Directly uses `sjcl.encrypt()` and `sjcl.decrypt()`.

Upon fetching the index container, it encrypts and persists just the current state of the collection (`this.collection.toJSON()`, no container history, etc) to localStorage. Subsequent logins, if the persisted local cache exists for that username, it decrypts it using their passphrase, then loads it into the index container updating the view. It then proceeds to fetch/sync from the server and displays a "Syncing entries.." message instead of the default "Decrypting entries..." until it completes the sync.
