### PR TITLE
Fix for display of multiline notes

### DIFF
--- a/tpl/entryView.html
+++ b/tpl/entryView.html
@@ -3,10 +3,12 @@
 	<!-- <li class="sep">Type</li>
 	<li><em>{{= it.type }}</em></li> -->
 	{{ _.each(it.items, function(item) { }}
-	{{? item.value }}<li class="sep">{{= item.key}}</li>
-	<li><a class="copyable {{= item.type === 'textarea' ? 'wrap' : ''}}">
-		{{= item.value }}
-	</a></li>{{? }}
+	  {{? item.value }}<li class="sep">{{= item.key}}</li>
+    <li>{{= item.type === 'textarea' ? '<pre>' : ''}}
+      <a class="copyable {{= item.type === 'textarea' ? 'wrap' : ''}}">
+		  {{= item.value }}
+      </a>
+    {{= item.type === 'textarea' ? '</pre>' : ''}}</li>{{? }}
 	{{ }); }}
 </ul>
 <ul><li class="entriesViewLoading loadingEntries sep">loading...</li></ul>

--- a/www/css/index.css
+++ b/www/css/index.css
@@ -481,8 +481,13 @@ ul li a.active {
 }
 ul li a.wrap {
   text-overflow: initial;
-  white-space: normal;
+  white-space: pre-wrap;
   overflow: auto;
+}
+ul li pre {
+  margin: 0;
+  padding: 0;
+  font-family: "Source Sans Pro", sans-serif;
 }
 ul li ::-webkit-input-placeholder {
   color: #8293a1;


### PR DESCRIPTION
Added a `pre` tag around the display of Notes fields and hit it with some font-family css to keep it from displaying as monospaced.
