### PR TITLE
Fixed Typo on Change Password

### DIFF
--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -162,7 +162,7 @@
       // Pop up a dialog to warn about how serious this is
       window.app.dialogConfirmView.show({
         title: "Warning - Changing Passphrase",
-        subtitle: "If forget your new passphrase your account will be unrecoverable! Continue?",
+        subtitle: "If you forget your new passphrase your account will be unrecoverable! Continue?",
         callback: function() {
           window.app.toastView.show("Passphrase unchanged");
         }


### PR DESCRIPTION
Warning message is missing a word:
"If you forget..."