### PR TITLE
Fix - Application crashes after network reconnect

### DIFF
--- a/src/views/MainView.js
+++ b/src/views/MainView.js
@@ -128,7 +128,6 @@
             });
           }, function(){
             self.updatingLocalStorage = false;
-            self.updateLocalStorage(containerChanged);
           });
         });
       } else {


### PR DESCRIPTION
Encryptr crashes under some circumstances when the network is reconnected.

Reproduce:
    Be disconnected to the internet.
    Log into your Encryptr account.
    Choose to 'lock' Encryptr.
    Enable the internet.
    appcrash.sad