### PR TITLE
Fix Item Name field is not saved to clipboard.

### DIFF
--- a/src/views/EntryView.js
+++ b/src/views/EntryView.js
@@ -82,7 +82,7 @@
       var type = $(event.target).attr('data-type');
       var key;
       if (type === 'Label') {
-        key = { value: this.model.label };
+        key = { value: this.model.toJSON().label };
       } else {
         key = _.findWhere(this.model.get("items"), { key: type });
       }


### PR DESCRIPTION
Across all entry types (credit card, password, note) the Item Name field, when double clicked, is not saved to the clipboard. There is, however, a notification generated that tells the user the field has been 'copied'.

##### Reproduce
 - Create a new 'Note' entry.
 - Fill out all fields and save the entry.
 - Return to the new Note and double click the 'Item Name'.
 - You should see a message saying the label was copied.
 - Attempt to paste the content.
 - invisibleink.jpg
