### PR TITLE
Fix Multiple scroll bars

### DIFF
--- a/src/views/AddMenuView.js
+++ b/src/views/AddMenuView.js
@@ -39,8 +39,7 @@
         var _this = this;
         this.$("input").attr("disabled", true);
         $(".subviews, .nav").removeClass("less");
-        $(".subviews").attr("style",
-            "overflow: auto !important; -webkit-overflow-scrolling: touch;");
+        $(".subviews").attr("style", "-webkit-overflow-scrolling: touch;");
         this.$el.animate("addMenuHide", 200, "ease-out", function() {
           _this.$el.addClass("dismissed");
         });
@@ -51,7 +50,6 @@
         this.$el.removeClass("dismissed");
         this.$("input").removeAttr("disabled");
         $(".subviews, .nav").addClass("less");
-        $(".subviews").attr("style", "overflow: hidden !important");
         this.$el.animate("addMenuShow", 200, "ease-in-out");
       }
     },


### PR DESCRIPTION
After taking some actions that will return you to the main Encryptr page, a second scrollbar will generate, this seems a bit unnecessary.
h5. 

##### Reproduce
 * Log into Encryptr and be on the "homescreen" to choose an entry.
 * Choose to add a new entry (doesn't matter which one).
 * Select the 'back' button and say 'yes' to discard at the prompt.
 * Once you have returned to the landing screen, view the multiple scroll bars.